### PR TITLE
Config: #7 SonarCloud 대시보드에 JaCoCo 커버리지 데이터 연동

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-     작업 진행 중(WIP) PR의 경우, Draft PR 기능을 사용해 주세요.
+     작업 진행 중(WIP)인 경우 반드시 Draft PR로 제출해 주세요.
      리뷰 후 추가 커밋을 force-push하는 것은 피해주세요.
 
      Pull Request 제출 전에 아래 사항을 확인해 주세요:
@@ -12,30 +12,32 @@
 ## 🏷️ PR Type (check all applicable)
 
 - [ ] ✨ Feature
-- [ ] ✅ Test
 - [ ] 🐛 Bug Fix
 - [ ] 🔧 Refactor
 - [ ] ⚡ Performance
+- [ ] ✅ Test
+- [ ] ⚙️ Configuration/Settings
 - [ ] 👷 CI/CD
-- [ ] 📝 Documentation Update
-- [ ] 📌 Etc
+- [ ] 📝 Documentation
+- [ ] 🔒 Security
+- [ ] 📌 Other
 
 ## 🚩 Summary
-<!-- 무엇을 왜 변경했는지 한 문장으로 요약 -->
+<!-- 주요 변경사항을 목록으로 작성해주세요 -->
 
-- 구현한 내용 설명1
-- 구현한 내용 설명2
+- [ ] 구현한 내용 설명1
+- [ ] 구현한 내용 설명2
 
 ## 🎫 Related Tickets
-<!-- 관련 이슈 혹은 티켓 번호 (예: #123, PROJ-456) -->
+<!-- 관련된 이슈나 티켓을 연결해주세요 (예: #123, PROJ-456) -->
 
-- 관련 이슈: #
+- Closes #
 
 ## ⚠️ Technical Concerns
-<!-- 메모리·성능·트랜잭션 등 주의할 기술적 사항을 간단히 기재 -->
+<!-- 성능, 메모리, 트랜잭션 등 기술적으로 고려해야 할 사항을 기재해주세요 -->
 
 ## 👀 To Reviewer
-<!-- 리뷰어가 참고할 핵심 포인트 혹은 질문 -->
+<!-- 리뷰어가 특별히 봐야 할 부분이나 질문이 있다면 작성해주세요 -->
 
 ## 📚 References
-<!-- 외부 참고 링크 -->
+<!-- 참고한 자료나 링크가 있다면 기재해주세요 -->

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
@@ -55,6 +56,29 @@ sonar {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        html.required = false
+        xml.required = true
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/*Request.class',
+                    '**/*Response.class',
+                    '**/*Dto.class',
+                    '**/*Exception.class',
+                    '**/*Config.class',
+                    '**/*Application.class',
+            ])
+        }))
+    }
 }
 
 tasks.named('asciidoctor') {

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
<!--
     작업 진행 중(WIP) PR의 경우, Draft PR 기능을 사용해 주세요.
     리뷰 후 추가 커밋을 force-push하는 것은 피해주세요.

     Pull Request 제출 전에 아래 사항을 확인해 주세요:
     - 👷‍♀️ 가능한 한 작은 단위의 PR 작성
     - ✅ 변경 사항에 대한 테스트 추가
     - 📝 커밋 메시지를 명확하게 작성
     - 📗 관련 문서와 스크린샷 업데이트
-->

## 🏷️ PR Type (check all applicable)

- [x] 📌 Etc

## 🚩 Summary
<!-- 무엇을 왜 변경했는지 한 문장으로 요약 -->

- [x] Gradle에 JaCoCo 플러그인 추가
- [x] 코드 커버리지 검사 대상에 Lombok으로 생성된 코드는 제외하도록 구성

## 🎫 Related Tickets
<!-- 관련 이슈 혹은 티켓 번호 (예: #123, PROJ-456) -->

- 관련 이슈: close #7

## ⚠️ Technical Concerns
<!-- 메모리·성능·트랜잭션 등 주의할 기술적 사항을 간단히 기재 -->

## 👀 To Reviewer
롬복이 자동으로 생성한 코드들에 대해서도 테스트 범위에서 제외해야 하는데, 프로젝트 루트에 `lombok.config`을 쓰고 아래와 같이 적으면 제외시킬 수 있습니다.

```yaml
# @lombok.Generated 애노테이션을 Lombok이 생성하는 코드에 추가하여, 이 코드가 Lombok이 자동으로 생성한 코드임을 나타낸다.
# 따라서 코드 커버리지 툴이나 스타일 검사 툴 등에서 해당 코드를 제외하도록 설정할 수 있으며, 실제로 개발자가 작성한 코드에만 집중할 수 있게 된다.
lombok.addLombokGeneratedAnnotation = true
```

## 📚 References
- [Lombok - Configuration system](https://projectlombok.org/features/configuration)